### PR TITLE
Fixing c# compile

### DIFF
--- a/src/logging/Logger.hx
+++ b/src/logging/Logger.hx
@@ -63,11 +63,6 @@ class Logger implements ILogger
     {
         var logger:ILogger = this;
         while (true) {
-            #if cpp
-            #elseif !flash
-            if (null != logger.level)
-                return logger.level;
-            #end
             if (null == logger)
                 break;
                 

--- a/src/logging/Logger.hx
+++ b/src/logging/Logger.hx
@@ -30,7 +30,6 @@ class Logger implements ILogger
         handlers = [];
         filterer = new Filterer();
         propagate = true;
-        this.level = level;
     }
 
     public function addFilter(filter:IFilter):Void


### PR DESCRIPTION
Logger.level is an Integer which gets set to 0 in the constructor. I'm not sure where it is possible to set the level to null.

This code is invalid when generating C# (or cpp or flash from the looks of it).
